### PR TITLE
Fix `watch` type derivation

### DIFF
--- a/src/functions/watch.ts
+++ b/src/functions/watch.ts
@@ -81,7 +81,7 @@ function createSingleSourceWatcher<T>(
   source: watchedValue<T>,
   cb: watcherCallBack<T>,
   options: WatcherOption
-) {
+): () => void {
   let getter: () => T;
   if (isWrapper<T>(source)) {
     getter = () => source.value;
@@ -128,7 +128,7 @@ function createMuiltSourceWatcher<T>(
   sources: Array<watchedValue<T>>,
   cb: watcherCallBack<T[]>,
   options: WatcherOption
-) {
+): () => void {
   let execCallbackAfterNumRun: false | number = options.lazy ? false : sources.length;
   let pendingCallback = false;
   const watcherContext: WatcherContext<T>[] = [];
@@ -209,10 +209,20 @@ function createMuiltSourceWatcher<T>(
 }
 
 export function watch<T>(
+  source: watchedValue<T>,
+  cb: watcherCallBack<T>,
+  options?: Partial<WatcherOption>
+): () => void;
+export function watch<T>(
+  source: watchedValue<T>[],
+  cb: watcherCallBack<T[]>,
+  options?: Partial<WatcherOption>
+): () => void;
+export function watch<T>(
   source: watchedValue<T> | Array<watchedValue<T>>,
   cb: watcherCallBack<T> | watcherCallBack<T[]>,
   options: Partial<WatcherOption> = {}
-) {
+): () => void {
   const opts: WatcherOption = {
     ...{
       lazy: false,


### PR DESCRIPTION
Add function overloads to improve type derivation

Before:
![image](https://user-images.githubusercontent.com/11247099/59855895-751af300-93a8-11e9-9935-1b6500579569.png)

After:
![image](https://user-images.githubusercontent.com/11247099/59856077-c3c88d00-93a8-11e9-986c-4570d723061f.png)

