### PR TITLE
Add English README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ yarn add vue-function-api
 # 使用
 ``` js
 import Vue from 'vue';
-import { plugin, value, computed, watch, onMounted } from 'vue-class-component'
+import { plugin, value, computed, watch, onMounted } from 'vue-function-api'
 
 Vue.use(plugin);
 
@@ -121,7 +121,7 @@ const MyComponent = {
 Example:
 
 ```js
-import { value } from 'vue'
+import { value } from 'vue-function-api'
 
 const MyComponent = {
   setup(props) {
@@ -139,7 +139,7 @@ const MyComponent = {
 ```
 
 ```js
-import { value } from 'vue'
+import { value } from 'vue-function-api'
 
 const MyComponent = {
   setup(props) {
@@ -164,7 +164,7 @@ const MyComponent = {
 Example:
 
 ```js
-import { state } from 'vue'
+import { state } from 'vue-function-api'
 
 const object = state({
   count: 0
@@ -181,7 +181,7 @@ object.count++
 Example:
 
 ```js
-import { value, computed } from 'vue'
+import { value, computed } from 'vue-function-api'
 
 const count = value(0)
 const countPlusOne = computed(() => count.value + 1)
@@ -255,7 +255,7 @@ watch(
 Example:
 
 ```js
-import { onMounted, onUpdated, onUnmounted } from 'vue'
+import { onMounted, onUpdated, onUnmounted } from 'vue-function-api'
 
 const MyComponent = {
   setup() {
@@ -282,7 +282,7 @@ const MyComponent = {
 Example:
 
 ```js
-import { provide, inject } from 'vue'
+import { provide, inject } from 'vue-function-api'
 
 const CountSymbol = Symbol()
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vue Function API
 
-> [Function-based Component API RFC](https://github.com/vuejs/rfcs/pull/42)
+> [Function-based Component API RFC](https://github.com/vuejs/rfcs/blob/function-apis/active-rfcs/0000-function-api.md)
 
 Future-Oriented Programming, `vue-function-api` provides function api from `Vue3.x` to `Vue2.x` for developering next-generation Vue applications.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # Vue Function API
 
-> [通过基于函数的 API 来复用组件逻辑](https://zhuanlan.zhihu.com/p/68477600)
+> [Function-based Component API RFC](https://github.com/vuejs/rfcs/pull/42)
 
-面向未来编程(Future-Oriented Programming)，`vue-function-api` 提供 Vue3 中的组件逻辑复用机制帮助开发者开发下一代 vue 应用程序，允许开发者利用 Vue3 的响应性 API 建设未来 Vue 生态。
+Future-Oriented Programming, `vue-function-api` provides function api from `Vue3.x` to `Vue2.x` for developering next-generation Vue applications.
+
+[**中文文档**](./README.zh-CN.md)
 
 ---
 
-# 导航
+# Navigation
 
-- [安装](#安装)
-- [使用](#使用)
+- [Installation](#Installation)
+- [Usage](#Usage)
 - [API](#API)
     -  [setup](#setup)
     -  [value](#value)
@@ -18,10 +20,9 @@
     -  [watch](#watch)
     -  [lifecycle](#lifecycle)
     -  [provide, inject](#provide-inject)
-    -  [Wrapper](#Wrapper)
-- [其他](#其他)
+- [Misc](#Misc)
 
-# 安装
+# Installation
 
 **npm** 
 ```bash
@@ -38,13 +39,13 @@ yarn add vue-function-api
 ```html
 <script src="https://unpkg.com/vue-function-api/dist/vue-function-api.umd.js"></script>
 ```
-通过全局变量 `window.vueFunctionApi` 来使用。
+By using the global variable `window.vueFunctionApi`
 
 **CodePen**
 
-[在线示例](https://codepen.io/liximomo/pen/dBOvgg)，fork 后进行测试或 bug 反馈。
+[Live Demo](https://codepen.io/liximomo/pen/dBOvgg)
 
-# 使用
+# Usage
 ``` js
 import Vue from 'vue';
 import { plugin, value, computed, watch, onMounted } from 'vue-function-api'
@@ -95,9 +96,8 @@ new Vue({
 
 ▸ **setup**(props: *`Props`*): `Object|undefined`
 
-组件现在接受一个新的 `setup` 选项，在这里我们利用函数 api 进行组件逻辑设置。
+A new component option, `setup()` is introduced. As the name suggests, this is the place where we use the function-based APIs to setup the logic of our component. `setup()` is called when an instance of the component is created, after props resolution. The function receives the resolved props as its first argument.
 
-`setup()` 中可以使用 `this` 访问当前组件实例, 大多数情况下我们并不需要访问它。
 
 Example:
 
@@ -112,11 +112,14 @@ const MyComponent = {
 }
 ```
 
+> **`this` is not available inside `setup()`.**
+
+
 ## value
 
 ▸ **value**(value: *`any`*): [`Wrapper`](#Wrapper)
 
-`value` 函数为组件声明一个响应式属性，我们只需要在 `setup` 函数中返回 `value` 的返回值即可。
+Calling `value()` returns a **value wrapper** object that contains a single reactive property: `.value`.
 
 Example:
 
@@ -159,7 +162,7 @@ const MyComponent = {
 ## state
 ▸ **state**(value: *`any`*)
 
-与 [`Vue.observable`](https://vuejs.org/v2/api/index.html#Vue-observable) 等价。
+Equivalent with [`Vue.observable`](https://vuejs.org/v2/api/index.html#Vue-observable).
 
 Example:
 
@@ -176,7 +179,7 @@ object.count++
 ## computed
 ▸ **computed**(getter: *`Function`*, setter?: *`Function`*): [`Wrapper`](#Wrapper)
 
-与 vue 2.x computed property 行为一致。
+Equivalent with computed property from `vue 2.x`.
 
 Example:
 
@@ -197,19 +200,18 @@ console.log(countPlusOne.value) // 2
 
 ▸ **watch**(source: *`Array<Wrapper | () => any>`*, callback: *`([newVal1, newVal2, ... newValN], [oldVal1, oldVal2, ... oldValN])`*, options?: *[`WatchOption`](#WatchOption)*): `Function` 
 
-`watch` 允许我们在相应的状态发生改变时执行一个回调函数。
+The `watch` API provides a way to perform side effect based on reactive state changes.
 
-**返回值** `Function`
-一个可调用的函数来停止 `watch`。
+**Returns** a `Function` to stop the `watch`.
 
-> [effect-cleanup](https://github.com/vuejs/rfcs/blob/function-apis/active-rfcs/0000-function-api.md#effect-cleanup) 当前并不支持。
+> [effect-cleanup](https://github.com/vuejs/rfcs/blob/function-apis/active-rfcs/0000-function-api.md#effect-cleanup) is NOT supported currently.
 
 ### WatchOption
 | Name | Type | Default | Description |
 | ------ | ------ | ------ | ------ |
-| lazy | `boolean` | `false` |  与 2.x `watch` 中的 `immediate` 选项含义相反. |
-| deep | `boolean` | `false` | 与 2.x 相同 |
-| flush | `"pre"` \| `"post"` \| `"sync"` | `"post"` | `"post"`: render 后触发; `"pre"`: render 前触发, `"sync"`: 同步触发 |
+| lazy | `boolean` | `false` | The opposite of 2.x's `immediate` option |
+| deep | `boolean` | `false` | Same as 2.x |
+| flush | `"pre"` \| `"post"` \| `"sync"` | `"post"` | `"post"`: fire after renderer flush; `"pre"`: fire before renderer flush; `"sync"`: fire synchronously |
 
 
 Example:
@@ -229,7 +231,7 @@ count.value++
 // -> count + 1 is: 2
 ```
 
-Example(Multiple Sources):
+Example (Multiple Sources):
 
 ```js
 watch(
@@ -250,7 +252,7 @@ watch(
 
 ▸ **onXXX**(cb: *`Function`*)
 
-支持 2.x 中除 `beforeCreated` 以外的所有生命周期函数，额外提供 `onUnmounted`。
+All current lifecycle hooks will have an equivalent `onXXX` function that can be used inside `setup()`
 
 Example:
 
@@ -277,7 +279,7 @@ const MyComponent = {
 
 ▸ **inject**(key: *`string` | `symbol`*)
 
-与 2.x 中的 `provide` 和 `inject` 选项行为一致。
+Equivalent with `provide` and `inject` from `2.x`
 
 Example:
 
@@ -306,85 +308,8 @@ const Descendent = {
 }
 ```
 
-## Wrapper (包装对象)
-> 以下内容引自 [尤雨溪知乎专栏](https://zhuanlan.zhihu.com/p/68477600)
+# Misc
 
-一个包装对象只有一个属性：`value` ，该属性指向内部被包装的值。
-
-
-### 为什么需要包装对象？
-我们知道在 JavaScript 中，原始值类型如 `string` 和 `number` 是只有值，没有引用的。如果在一个函数中返回一个字符串变量，接收到这个字符串的代码只会获得一个值，是无法追踪原始变量后续的变化的。
-
-因此，包装对象的意义就在于提供一个让我们能够在函数之间以引用的方式传递任意类型值的容器。这有点像 React Hooks 中的 `useRef` —— 但不同的是 Vue 的包装对象同时还是响应式的数据源。有了这样的容器，我们就可以在封装了逻辑的组合函数中将状态以引用的方式传回给组件。组件负责展示（追踪依赖），组合函数负责管理状态（触发更新）：
-```js
-setup() {
-  const valueA = useLogicA() // valueA 可能被 useLogicA() 内部的代码修改从而触发更新
-  const valueB = useLogicB()
-  return {
-    valueA,
-    valueB
-  }
-}
-```
-
-包装对象也可以包装非原始值类型的数据，被包装的对象中嵌套的属性都会被响应式地追踪。用包装对象去包装对象或是数组并不是没有意义的：它让我们可以对整个对象的值进行替换 —— 比如用一个 filter 过的数组去替代原数组：
-```js
-const numbers = value([1, 2, 3])
-// 替代原数组，但引用不变
-numbers.value = numbers.value.filter(n => n > 1)
-```
-
-如果你依然想创建一个没有包装的响应式对象，可以使用 `state` API（和 2.x 的 `Vue.observable()` 等同）：
-```js
-import { state } from 'vue'
-
-const object = state({
-  count: 0
-})
-
-object.count++
-```
-
-### Value Unwrapping（包装对象的自动展开）
-
-当包装对象被暴露给模版渲染上下文，或是被嵌套在另一个响应式对象中的时候，它会被自动展开 (unwrap) 为内部的值。
-
-比如一个包装对象的绑定可以直接被模版中的内联函数修改：
-```js
-const MyComponent = {
-  setup() {
-    return {
-      count: value(0)
-    }
-  },
-  template: `<button @click="count++">{{ count }}</button>`
-}
-```
-
-当一个包装对象被作为另一个响应式对象的属性引用的时候也会被自动展开：
-
-```js
-const count = value(0)
-const obj = state({
-  count
-})
-
-console.log(obj.count) // 0
-
-obj.count++
-console.log(obj.count) // 1
-console.log(count.value) // 1
-
-count.value++
-console.log(obj.count) // 2
-console.log(count.value) // 2
-```
-
-以上这些关于包装对象的细节可能会让你觉得有些复杂，但实际使用中你只需要记住一个基本的规则：只有当你直接以变量的形式引用一个包装对象的时候才会需要用 `.value` 去取它内部的值 —— 在模版中你甚至不需要知道它们的存在。
-
-
-# 其他
-
-- vue-function-api 会一直保持与 Vue3.x 的兼容性，当 3.0 发布时，您可以无缝替换掉本库。
-- vue-function-api 的实现只依赖 Vue2.x 本身，不伦 Vue3.x 的发布与否，都不会影响您正常使用本库。
-- 由于 Vue2.x 的公共 api 限制，vue-function-api 无法避免的会产生一些额外的内存负载。如果您的应用并不工作在极端内存环境下，无需关心此项。
+- `vue-function-api` will keep updated with `Vue3.x` API. When `3.0` released, you can replace this library seamlessly.
+- `vue-function-api` only relies on `Vue2.x` itself. Wheather `Vue3.x` is released or not, it's not affect you using this library.
+- Due the the limitation of `Vue2.x`'s public API. `vue-function-api` inevitably introduce some extract workload. It doesn't concern you if you are now working on extreme environment.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,392 @@
+# Vue Function API
+
+> [通过基于函数的 API 来复用组件逻辑](https://zhuanlan.zhihu.com/p/68477600)
+
+面向未来编程(Future-Oriented Programming)，`vue-function-api` 提供 Vue3 中的组件逻辑复用机制帮助开发者开发下一代 vue 应用程序，允许开发者利用 Vue3 的响应性 API 建设未来 Vue 生态。
+
+[**English Version**](./README.md)
+
+---
+
+# 导航
+
+- [安装](#安装)
+- [使用](#使用)
+- [API](#API)
+    -  [setup](#setup)
+    -  [value](#value)
+    -  [state](#state)
+    -  [computed](#computed)
+    -  [watch](#watch)
+    -  [lifecycle](#lifecycle)
+    -  [provide, inject](#provide-inject)
+    -  [Wrapper](#Wrapper)
+- [其他](#其他)
+
+# 安装
+
+**npm** 
+```bash
+npm install vue-function-api --save
+```
+
+**yarn**
+```bash
+yarn add vue-function-api
+```
+
+**CDN**
+
+```html
+<script src="https://unpkg.com/vue-function-api/dist/vue-function-api.umd.js"></script>
+```
+通过全局变量 `window.vueFunctionApi` 来使用。
+
+**CodePen**
+
+[在线示例](https://codepen.io/liximomo/pen/dBOvgg)，fork 后进行测试或 bug 反馈。
+
+# 使用
+``` js
+import Vue from 'vue';
+import { plugin, value, computed, watch, onMounted } from 'vue-function-api'
+
+Vue.use(plugin);
+
+new Vue({
+  template: `
+    <div>
+      <span>count is {{ count }}</span>
+      <span>plusOne is {{ plusOne }}</span>
+      <button @click="increment">count++</button>
+    </div>
+  `,
+  setup() {
+    // reactive state
+    const count = value(0);
+    // computed state
+    const plusOne = computed(() => count.value + 1);
+    // method
+    const increment = () => {
+      count.value++;
+    };
+    // watch
+    watch(
+      () => count.value * 2,
+      val => {
+        console.log(`count * 2 is ${val}`);
+      }
+    );
+    // lifecycle
+    onMounted(() => {
+      console.log(`mounted`);
+    });
+    // expose bindings on render context
+    return {
+      count,
+      plusOne,
+      increment,
+    };
+  },
+}).$mount('#app');
+```
+
+# API
+
+## setup
+
+▸ **setup**(props: *`Props`*): `Object|undefined`
+
+组件现在接受一个新的 `setup` 选项，在这里我们利用函数 api 进行组件逻辑设置。
+
+`setup()` 中可以使用 `this` 访问当前组件实例, 大多数情况下我们并不需要访问它。
+
+Example:
+
+```js
+const MyComponent = {
+  props: {
+    name: String
+  },
+  setup(props) {
+    console.log(props.name)
+  }
+}
+```
+
+## value
+
+▸ **value**(value: *`any`*): [`Wrapper`](#Wrapper)
+
+`value` 函数为组件声明一个响应式属性，我们只需要在 `setup` 函数中返回 `value` 的返回值即可。
+
+Example:
+
+```js
+import { value } from 'vue-function-api'
+
+const MyComponent = {
+  setup(props) {
+    const msg = value('hello')
+    const appendName = () => {
+      msg.value = `hello ${props.name}`
+    }
+    return {
+      msg,
+      appendName
+    }
+  },
+  template: `<div @click="appendName">{{ msg }}</div>`
+}
+```
+
+```js
+import { value } from 'vue-function-api'
+
+const MyComponent = {
+  setup(props) {
+    const msg = value('hello')
+    const appendName = () => {
+      msg.value = `hello ${props.name}`
+    }
+    return {
+      msg,
+      appendName
+    }
+  },
+  template: `<div @click="appendName">{{ msg }}</div>`
+}
+```
+
+## state
+▸ **state**(value: *`any`*)
+
+与 [`Vue.observable`](https://vuejs.org/v2/api/index.html#Vue-observable) 等价。
+
+Example:
+
+```js
+import { state } from 'vue-function-api'
+
+const object = state({
+  count: 0
+})
+
+object.count++
+```
+
+## computed
+▸ **computed**(getter: *`Function`*, setter?: *`Function`*): [`Wrapper`](#Wrapper)
+
+与 vue 2.x computed property 行为一致。
+
+Example:
+
+```js
+import { value, computed } from 'vue-function-api'
+
+const count = value(0)
+const countPlusOne = computed(() => count.value + 1)
+
+console.log(countPlusOne.value) // 1
+
+count.value++
+console.log(countPlusOne.value) // 2
+```
+
+## watch
+▸ **watch**(source: *`Wrapper | () => any`*, callback: *`(newVal, oldVal)`*, options?: *[`WatchOption`](#WatchOption)*): `Function` 
+
+▸ **watch**(source: *`Array<Wrapper | () => any>`*, callback: *`([newVal1, newVal2, ... newValN], [oldVal1, oldVal2, ... oldValN])`*, options?: *[`WatchOption`](#WatchOption)*): `Function` 
+
+`watch` 允许我们在相应的状态发生改变时执行一个回调函数。
+
+**返回值** `Function`
+一个可调用的函数来停止 `watch`。
+
+> [effect-cleanup](https://github.com/vuejs/rfcs/blob/function-apis/active-rfcs/0000-function-api.md#effect-cleanup) 当前并不支持。
+
+### WatchOption
+| Name | Type | Default | Description |
+| ------ | ------ | ------ | ------ |
+| lazy | `boolean` | `false` |  与 2.x `watch` 中的 `immediate` 选项含义相反. |
+| deep | `boolean` | `false` | 与 2.x 相同 |
+| flush | `"pre"` \| `"post"` \| `"sync"` | `"post"` | `"post"`: render 后触发; `"pre"`: render 前触发, `"sync"`: 同步触发 |
+
+
+Example:
+
+```js
+watch(
+  // getter
+  () => count.value + 1,
+  // callback
+  (value, oldValue) => {
+    console.log('count + 1 is: ', value)
+  }
+)
+// -> count + 1 is: 1
+
+count.value++
+// -> count + 1 is: 2
+```
+
+Example(Multiple Sources):
+
+```js
+watch(
+  [valueA, () => valueB.value],
+  ([a, b], [prevA, prevB]) => {
+    console.log(`a is: ${a}`)
+    console.log(`b is: ${b}`)
+  }
+)
+```
+
+## lifecycle
+▸ **onCreated**(cb: *`Function`*)
+
+▸ **onBeforeMount**(cb: *`Function`*)
+
+▸ **onMounted**(cb: *`Function`*)
+
+▸ **onXXX**(cb: *`Function`*)
+
+支持 2.x 中除 `beforeCreated` 以外的所有生命周期函数，额外提供 `onUnmounted`。
+
+Example:
+
+```js
+import { onMounted, onUpdated, onUnmounted } from 'vue-function-api'
+
+const MyComponent = {
+  setup() {
+    onMounted(() => {
+      console.log('mounted!')
+    })
+    onUpdated(() => {
+      console.log('updated!')
+    })
+    onUnmounted(() => {
+      console.log('unmounted!')
+    })
+  }
+}
+```
+
+## provide, inject
+▸ **provide**(value: *`Object`*)
+
+▸ **inject**(key: *`string` | `symbol`*)
+
+与 2.x 中的 `provide` 和 `inject` 选项行为一致。
+
+Example:
+
+```js
+import { provide, inject } from 'vue-function-api'
+
+const CountSymbol = Symbol()
+
+const Ancestor = {
+  setup() {
+    // providing a value can make it reactive
+    const count = value(0)
+    provide({
+      [CountSymbol]: count
+    })
+  }
+}
+
+const Descendent = {
+  setup() {
+    const count = inject(CountSymbol)
+    return {
+      count
+    }
+  }
+}
+```
+
+## Wrapper (包装对象)
+> 以下内容引自 [尤雨溪知乎专栏](https://zhuanlan.zhihu.com/p/68477600)
+
+一个包装对象只有一个属性：`value` ，该属性指向内部被包装的值。
+
+
+### 为什么需要包装对象？
+我们知道在 JavaScript 中，原始值类型如 `string` 和 `number` 是只有值，没有引用的。如果在一个函数中返回一个字符串变量，接收到这个字符串的代码只会获得一个值，是无法追踪原始变量后续的变化的。
+
+因此，包装对象的意义就在于提供一个让我们能够在函数之间以引用的方式传递任意类型值的容器。这有点像 React Hooks 中的 `useRef` —— 但不同的是 Vue 的包装对象同时还是响应式的数据源。有了这样的容器，我们就可以在封装了逻辑的组合函数中将状态以引用的方式传回给组件。组件负责展示（追踪依赖），组合函数负责管理状态（触发更新）：
+```js
+setup() {
+  const valueA = useLogicA() // valueA 可能被 useLogicA() 内部的代码修改从而触发更新
+  const valueB = useLogicB()
+  return {
+    valueA,
+    valueB
+  }
+}
+```
+
+包装对象也可以包装非原始值类型的数据，被包装的对象中嵌套的属性都会被响应式地追踪。用包装对象去包装对象或是数组并不是没有意义的：它让我们可以对整个对象的值进行替换 —— 比如用一个 filter 过的数组去替代原数组：
+```js
+const numbers = value([1, 2, 3])
+// 替代原数组，但引用不变
+numbers.value = numbers.value.filter(n => n > 1)
+```
+
+如果你依然想创建一个没有包装的响应式对象，可以使用 `state` API（和 2.x 的 `Vue.observable()` 等同）：
+```js
+import { state } from 'vue'
+
+const object = state({
+  count: 0
+})
+
+object.count++
+```
+
+### Value Unwrapping（包装对象的自动展开）
+
+当包装对象被暴露给模版渲染上下文，或是被嵌套在另一个响应式对象中的时候，它会被自动展开 (unwrap) 为内部的值。
+
+比如一个包装对象的绑定可以直接被模版中的内联函数修改：
+```js
+const MyComponent = {
+  setup() {
+    return {
+      count: value(0)
+    }
+  },
+  template: `<button @click="count++">{{ count }}</button>`
+}
+```
+
+当一个包装对象被作为另一个响应式对象的属性引用的时候也会被自动展开：
+
+```js
+const count = value(0)
+const obj = state({
+  count
+})
+
+console.log(obj.count) // 0
+
+obj.count++
+console.log(obj.count) // 1
+console.log(count.value) // 1
+
+count.value++
+console.log(obj.count) // 2
+console.log(count.value) // 2
+```
+
+以上这些关于包装对象的细节可能会让你觉得有些复杂，但实际使用中你只需要记住一个基本的规则：只有当你直接以变量的形式引用一个包装对象的时候才会需要用 `.value` 去取它内部的值 —— 在模版中你甚至不需要知道它们的存在。
+
+
+# 其他
+
+- `vue-function-api` 会一直保持与 `Vue3.x` 的兼容性，当 `3.0` 发布时，您可以无缝替换掉本库。
+- `vue-function-api` 的实现只依赖 `Vue2.x` 本身，不伦 `Vue3.x` 的发布与否，都不会影响您正常使用本库。
+- 由于 `Vue2.x` 的公共 API 限制，`vue-function-api` 无法避免的会产生一些额外的内存负载。如果您的应用并不工作在极端内存环境下，无需关心此项。


### PR DESCRIPTION
Resolves #3

**Changes**
- Rename the original `README.md` to `README.zh-CN.md`
- Translate English version to `README.md`
- Add links to refer each other.

I would suggest to use English version as default README. If you prefer Chinese version I would love to change.

[**Rendered**](https://github.com/antfu/vue-function-api/blob/docs-en-readme/README.md)